### PR TITLE
Add responsive Next.js template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RattleNext
 
-This repository contains a minimal backbone for a scalable web application using Next.js for the frontend and FastAPI for the backend.
+This repository contains a minimal backbone for a scalable web application using Next.js for the frontend and FastAPI for the backend. The frontend comes with a responsive template architecture including sample `index` and `login` pages.
 
 ## Tech Stack
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
 # RattleNext Frontend
 
-This is a Next.js application using Tailwind CSS and React Hook Form with Zod for validation.
+This is a Next.js application using Tailwind CSS and React Hook Form with Zod for validation. Base UI components are provided via shadcn/ui styled in the `components/ui` directory. Sample pages include `index` and `login`.
 
 ## Available Scripts
 

--- a/frontend/components/layout/DefaultLayout.tsx
+++ b/frontend/components/layout/DefaultLayout.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from "react"
+import Head from "next/head"
+
+export default function DefaultLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <Head>
+        <title>RattleNext</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <div className="min-h-screen flex flex-col">
+        <header className="bg-gray-900 text-white p-4">
+          <div className="container mx-auto">
+            <h1 className="text-xl font-semibold">RattleNext</h1>
+          </div>
+        </header>
+        <main className="flex-grow container mx-auto p-4">{children}</main>
+      </div>
+    </>
+  )
+}

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -1,0 +1,44 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "../../lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-blue-600 text-white hover:bg-blue-700",
+        ghost: "hover:bg-gray-100",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 px-3",
+        lg: "h-11 px-8",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+
+import { cn } from "../../lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-white px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Input.displayName = "Input"
+
+export { Input }

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,10 @@
     "react-hook-form": "latest",
     "zod": "latest",
     "@hookform/resolvers": "latest",
-    "tailwind-merge": "latest"
+    "tailwind-merge": "latest",
+    "clsx": "latest",
+    "class-variance-authority": "latest",
+    "@radix-ui/react-slot": "latest"
   },
   "devDependencies": {
     "autoprefixer": "latest",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,7 +1,12 @@
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
+import DefaultLayout from '../components/layout/DefaultLayout'
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <DefaultLayout>
+      <Component {...pageProps} />
+    </DefaultLayout>
+  )
 }
 export default MyApp

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
-import Head from 'next/head'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { Input } from '../components/ui/input'
+import { Button } from '../components/ui/button'
 
 const schema = z.object({
   name: z.string().min(1, 'Name is required'),
@@ -20,18 +20,13 @@ export default function Home() {
   }
 
   return (
-    <>
-      <Head>
-        <title>RattleNext</title>
-      </Head>
-      <main className="p-4">
-        <h1 className="text-2xl font-bold mb-4">Welcome to RattleNext</h1>
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
-          <input className="border p-2" placeholder="Name" {...register('name')} />
-          {errors.name && <p className="text-red-500">{errors.name.message}</p>}
-          <button type="submit" className="bg-blue-500 text-white px-4 py-2">Submit</button>
-        </form>
-      </main>
-    </>
+    <div className="max-w-md mx-auto space-y-2">
+      <h2 className="text-xl font-semibold">Welcome to RattleNext</h2>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+        <Input placeholder="Name" {...register('name')} />
+        {errors.name && <p className="text-red-500">{errors.name.message}</p>}
+        <Button type="submit">Submit</Button>
+      </form>
+    </div>
   )
 }

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,0 +1,35 @@
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Input } from '../components/ui/input'
+import { Button } from '../components/ui/button'
+
+const loginSchema = z.object({
+  email: z.string().email('Invalid email'),
+  password: z.string().min(6, 'Password must be at least 6 characters')
+})
+
+type LoginData = z.infer<typeof loginSchema>
+
+export default function Login() {
+  const { register, handleSubmit, formState: { errors } } = useForm<LoginData>({
+    resolver: zodResolver(loginSchema)
+  })
+
+  const onSubmit = (data: LoginData) => {
+    console.log(data)
+  }
+
+  return (
+    <div className="max-w-sm mx-auto space-y-4">
+      <h2 className="text-xl font-semibold text-center">Login</h2>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+        <Input placeholder="Email" type="email" {...register('email')} />
+        {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
+        <Input placeholder="Password" type="password" {...register('password')} />
+        {errors.password && <p className="text-red-500 text-sm">{errors.password.message}</p>}
+        <Button className="w-full" type="submit">Login</Button>
+      </form>
+    </div>
+  )
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RattleNext</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.3.2/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+  <h1 class="text-2xl font-bold mb-4">Welcome to RattleNext</h1>
+  <p>This static template demonstrates the basic styling.</p>
+</body>
+</html>

--- a/frontend/public/login.html
+++ b/frontend/public/login.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login - RattleNext</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.3.2/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+  <div class="max-w-sm mx-auto space-y-4">
+    <h2 class="text-xl font-semibold text-center">Login</h2>
+    <form class="space-y-2">
+      <input class="w-full border px-3 py-2" placeholder="Email" type="email" />
+      <input class="w-full border px-3 py-2" placeholder="Password" type="password" />
+      <button class="w-full bg-blue-600 text-white px-4 py-2 rounded" type="button">Login</button>
+    </form>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold scalable Next.js template with responsive layout
- add shadcn-style button and input components
- wrap app with DefaultLayout
- implement index and login pages using React Hook Form and Zod
- ship static `index.html` and `login.html` samples
- document new setup in READMEs

## Testing
- `npm install` *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68860e2e0dbc8327bfbaa345a37133e0